### PR TITLE
fix: improve light-mode contrast on profile view

### DIFF
--- a/components/renown-card.tsx
+++ b/components/renown-card.tsx
@@ -9,7 +9,7 @@ interface RenownCardProps {
 
 export const RenownCard: React.FC<RenownCardProps> = ({ children, className = "" }) => {
   return (
-    <div className={`overflow-hidden rounded-2xl border border-white/20 bg-white/10 shadow-2xl backdrop-blur-lg ${className}`}>
+    <div className={`overflow-hidden rounded-2xl border border-gray-200 bg-white/80 shadow-2xl backdrop-blur-lg dark:border-white/20 dark:bg-white/10 ${className}`}>
       {/* Card Header */}
       <div className="relative h-[106px]">
         <Image

--- a/pages/profile/[id].tsx
+++ b/pages/profile/[id].tsx
@@ -25,7 +25,7 @@ const ProfilePage: NextPage<ProfilePageProps> = ({ profile, error }) => {
         <main className={styles.main}>
           <div className="flex min-h-screen flex-col items-center justify-center">
             <h1 className="text-red-500 mb-4 text-2xl font-bold">Error</h1>
-            <p className="text-gray-400">{error}</p>
+            <p className="text-gray-600 dark:text-gray-400">{error}</p>
           </div>
         </main>
       </div>
@@ -43,8 +43,10 @@ const ProfilePage: NextPage<ProfilePageProps> = ({ profile, error }) => {
 
         <main className={styles.main}>
           <div className="flex min-h-screen flex-col items-center justify-center">
-            <h1 className="mb-4 text-2xl font-bold text-gray-400">Profile Not Found</h1>
-            <p className="text-gray-500">
+            <h1 className="mb-4 text-2xl font-bold text-gray-700 dark:text-gray-400">
+              Profile Not Found
+            </h1>
+            <p className="text-gray-600 dark:text-gray-500">
               The profile you&apos;re looking for doesn&apos;t exist or has been removed.
             </p>
           </div>
@@ -86,24 +88,26 @@ const ProfilePage: NextPage<ProfilePageProps> = ({ profile, error }) => {
               </div>
 
               {/* Username */}
-              <h1 className="mb-6 text-center text-3xl font-bold text-white">{displayName}</h1>
+              <h1 className="mb-6 text-center text-3xl font-bold text-gray-900 dark:text-white">
+                {displayName}
+              </h1>
 
               {/* Profile Details */}
               <div className="mt-8 space-y-4">
-                <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+                <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-white/10 dark:bg-white/5">
                   <div className="flex items-center justify-between">
-                    <span className="text-sm text-gray-400">RenownID</span>
-                    <span className="break-all font-mono text-sm text-white">
+                    <span className="text-sm text-gray-600 dark:text-gray-400">RenownID</span>
+                    <span className="break-all font-mono text-sm text-gray-900 dark:text-white">
                       {profile.documentId}
                     </span>
                   </div>
                 </div>
 
                 {profile.ethAddress && (
-                  <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+                  <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-white/10 dark:bg-white/5">
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-400">ETH Address</span>
-                      <span className="break-all font-mono text-xs text-white">
+                      <span className="text-sm text-gray-600 dark:text-gray-400">ETH Address</span>
+                      <span className="break-all font-mono text-xs text-gray-900 dark:text-white">
                         {profile.ethAddress}
                       </span>
                     </div>
@@ -111,10 +115,10 @@ const ProfilePage: NextPage<ProfilePageProps> = ({ profile, error }) => {
                 )}
 
                 {profile.createdAt && (
-                  <div className="rounded-lg border border-white/10 bg-white/5 p-4">
+                  <div className="rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-white/10 dark:bg-white/5">
                     <div className="flex items-center justify-between">
-                      <span className="text-sm text-gray-400">Member Since</span>
-                      <span className="text-sm text-white">
+                      <span className="text-sm text-gray-600 dark:text-gray-400">Member Since</span>
+                      <span className="text-sm text-gray-900 dark:text-white">
                         {new Date(profile.createdAt).toLocaleDateString('en-US', {
                           year: 'numeric',
                           month: 'long',


### PR DESCRIPTION
## Summary
- Profile view (`pages/profile/[id].tsx`) was dark-only — `text-white`, `text-gray-400`, `border-white/10`, `bg-white/5` all unconditional. With `PageBackground`'s `bg-white/90` light overlay, username/values/labels rendered white-on-white.
- Added `dark:` variants on the username, field rows (RenownID / ETH Address / Member Since), error + "not found" copy: light defaults use `text-gray-900` / `text-gray-600` / `border-gray-200` / `bg-gray-50`; dark variants preserve the existing styling.
- Updated `RenownCard` surface to `bg-white/80 border-gray-200` in light mode (`dark:bg-white/10 dark:border-white/20` unchanged). Other consumers (`connect-flow`, `console-flow`) layer their own opaque `bg-bg` panel inside, so only the rim improves — no regression to those flows.

Closes #2502

## Test plan
- [ ] Visit a profile URL in dark mode — appearance unchanged (frosted glass, white text)
- [ ] Toggle to light mode — username, RenownID, ETH address, and Member Since are clearly readable; field rows have visible borders and subtle gray fill; card has a visible gray border and shadow
- [ ] Visit `/profile/<nonexistent>` in light mode — "Profile Not Found" heading and subtext are readable
- [ ] Spot-check `/` (connect flow) and console flow in light mode — content panels still render correctly (only the card rim changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)