### PR TITLE
OpenPanel analytics env vars (build-args)

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -98,3 +98,5 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             TAG=${{ steps.get_version.outputs.version || github.ref_name }}
+            NEXT_PUBLIC_OPENPANEL_CLIENT_ID=7496b8b9-281d-40c7-af8e-541aaa228af8
+            NEXT_PUBLIC_OPENPANEL_API_URL=https://openpanel.monitoring.vetra.io/api


### PR DESCRIPTION
Passes the public OpenPanel NEXT_PUBLIC_OPENPANEL_CLIENT_ID + NEXT_PUBLIC_OPENPANEL_API_URL as docker build-args so they're baked into the renown-app image at next build.

The Dockerfile already declares these ARGs (commit 5e7e7b5); this wires the values through CI. renown.vetra.io is served from the k8s renown namespace (image cr.vetra.io/renown/renown-app), so the docker build is where NEXT_PUBLIC_* must be set. Values are public (browser-exposed Web-SDK client id).