### PR TITLE
Fix Vercel build: declare packageManager pnpm@10.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "renown-placeholder",
   "private": true,
   "version": "0.1.0",
+  "packageManager": "pnpm@10.1.0",
   "engines": {
     "node": "24.x"
   },


### PR DESCRIPTION
## Problem
Vercel build fails at `pnpm install`:
```
Using pnpm@9.x based on project creation date
ERROR  packages field missing or empty
```
Our `pnpm-workspace.yaml` holds only settings (`allowBuilds:`) with no `packages:` field — a pnpm@10 idiom. pnpm@9 (Vercel's default) treats it as a workspace root and requires `packages:`.

## Fix
Declare `"packageManager": "pnpm@10.1.0"` so Vercel uses pnpm@10 via corepack. Matches what already runs everywhere else:
- Dockerfile: `corepack install --global pnpm@10.1.0`
- CI (`semantic-release.yml`): `pnpm/action-setup@v3` `version: 10`

No lockfile change (the error is workspace-detection, not a lockfile mismatch).