### PR TITLE
Fix pnpm-workspace.yaml: unblock CI + Vercel builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,7 +1,15 @@
-allowBuilds:
-  '@reown/appkit': true
-  bufferutil: true
-  keccak: true
-  sharp: true
-  unrs-resolver: true
-  utf-8-validate: true
+# pnpm requires a `packages` field whenever this file exists. This is a
+# single-package repo, so the root is the only member.
+packages:
+  - '.'
+# Replaces the invalid `allowBuilds` key (which made `pnpm install` fail with
+# "packages field missing or empty" on pnpm 9/10/11, breaking CI + Vercel).
+# `onlyBuiltDependencies` is the pnpm@10 way to approve dependency build
+# scripts — these are transitive native modules that need to compile.
+onlyBuiltDependencies:
+  - '@reown/appkit'
+  - bufferutil
+  - keccak
+  - sharp
+  - unrs-resolver
+  - utf-8-validate


### PR DESCRIPTION
## Problem
`pnpm install` fails with `ERROR  packages field missing or empty` on pnpm 9/10/11 — breaking the CI image build ("Install dependencies" step) and the Vercel build. Reproduced locally with pnpm@10.1.0 and pnpm@11.3.0.

Root cause: the `initial openpanel implementation` commit added a `pnpm-workspace.yaml` with an invalid `allowBuilds` key and no `packages` field. pnpm treats the file as a workspace root and requires `packages`.

## Fix
- Add `packages: ['.']` (single-package repo, root is the only member).
- Convert `allowBuilds` → `onlyBuiltDependencies` (the valid pnpm@10 key) to preserve build-script approval for the transitive native deps.

Verified `pnpm@10.1.0 install --frozen-lockfile` succeeds with no lockfile change. Pairs with the already-merged `packageManager: pnpm@10.1.0` so Vercel uses pnpm@10 via corepack.