### PR TITLE
Fix frozen-install: move pnpm overrides into pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,5 @@
     "semantic-release": "^23.0.0",
     "tailwindcss": "^4.1.16",
     "typescript": "^5.9.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "@types/react": "19.2.14",
-      "@faker-js/faker": "8.4.1"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,3 +13,6 @@ onlyBuiltDependencies:
   - sharp
   - unrs-resolver
   - utf-8-validate
+overrides:
+  '@types/react': 19.2.14
+  '@faker-js/faker': 8.4.1


### PR DESCRIPTION
## Problem
After the previous fix, CI/Vercel install moved past the `packages field` error to:
```
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH: the current "overrides" configuration doesn't match the value found in the lockfile
```
pnpm@10 reads `overrides` from `pnpm-workspace.yaml`, not the deprecated `package.json` `pnpm` field. With the workspace file now present, pnpm saw no overrides while the lockfile recorded them.

## Fix
Move `overrides` into `pnpm-workspace.yaml`; remove the now-empty `pnpm` field from `package.json`.

Verified in a clean checkout: `corepack pnpm@10.1.0 install --frozen-lockfile` resolves all 1218 packages with no config mismatch.