### PR TITLE
fix: credential API returns eip712 proof without domain, breaking SDK login

### DIFF
--- a/pages/api/auth/credential.ts
+++ b/pages/api/auth/credential.ts
@@ -2,6 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next/types'
 import { allowCors } from '../[utils]'
 import { GraphQLClient } from 'graphql-request'
 import { revokeCredential } from '../../../services/renown-credential'
+import { CREDENTIAL_TYPES } from '../../../services/wallet'
 import { DEFAULT_DRIVE_ID } from '../../../utils/constants'
 
 const SWITCHBOARD_ENDPOINT =
@@ -137,11 +138,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         return prev.issuanceDate > curr.issuanceDate ? prev : curr
       })
 
-      // Parse EIP-712 domain from JSON string
+      // Parse EIP-712 domain from JSON string. The processor stores the
+      // domain object itself (e.g. {"version":"1","chainId":1}), but also
+      // accept a legacy wrapper shape ({domain, types}) just in case.
       let eip712Domain
       try {
-        eip712Domain = JSON.parse(credential.proofEip712Domain)
+        const parsed = JSON.parse(credential.proofEip712Domain)
+        eip712Domain = parsed?.domain ?? parsed
       } catch {
+        eip712Domain = null
+      }
+      if (eip712Domain && typeof eip712Domain.chainId !== 'number') {
         eip712Domain = null
       }
 
@@ -207,8 +214,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
             proofValue: credential.proofValue,
             eip712: eip712Domain
               ? {
-                  domain: eip712Domain.domain,
-                  types: eip712Domain.types,
+                  domain: eip712Domain,
+                  types: CREDENTIAL_TYPES,
                   primaryType: credential.proofEip712PrimaryType as 'VerifiableCredential',
                 }
               : undefined,


### PR DESCRIPTION
## Problem

Renown login in Connect fails with `Cannot read properties of undefined (reading 'chainId')` since `@renown/sdk` added strict EIP-712 credential verification (ph-monorepo `069417a20`, June 2).

The renown-credential processor stores the EIP-712 domain object itself as JSON in `proofEip712Domain` (e.g. `{"version":"1","chainId":1}`), but `GET /api/auth/credential` treats the parsed value as a wrapper and returns `domain: eip712Domain.domain` / `types: eip712Domain.types` — both `undefined`. The SDK then dereferences `credential.proof.eip712.domain.chainId` and throws, so login always fails.

## Fix

- Use the parsed JSON as the domain directly (still accepting a legacy `{domain, types}` wrapper shape, and dropping malformed values without a numeric `chainId`).
- Return the canonical `CREDENTIAL_TYPES` (from `services/wallet`) as `types`, since types were never stored per-credential.

## Validation

- `tsc --noEmit` and `eslint` pass.
- No unit-test harness exists in this repo (Playwright e2e only); the wire-contract regression tests live in the SDK (`ph-monorepo/packages/renown/test/renown.test.ts`, "deployed credential API compatibility"), which also gained a fallback that reconstructs the canonical domain so existing deployments keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)