### PR TITLE
feat: hide topbar login button during auth confirm flows

### DIFF
--- a/components/ui/page-background.tsx
+++ b/components/ui/page-background.tsx
@@ -8,9 +8,17 @@ import RenownLoginButton from "../auth/renown-login-button";
 
 interface PageBackgroundProps {
   children: React.ReactNode;
+  /**
+   * Hide the top-right login button. Used during auth/confirm flows where the
+   * user should act on the card instead of the topbar login.
+   */
+  hideLoginButton?: boolean;
 }
 
-const PageBackground: React.FC<PageBackgroundProps> = ({ children }) => {
+const PageBackground: React.FC<PageBackgroundProps> = ({
+  children,
+  hideLoginButton = false,
+}) => {
   return (
     <div className="relative overflow-hidden min-h-screen">
       {/* Dark mode background images */}
@@ -41,7 +49,7 @@ const PageBackground: React.FC<PageBackgroundProps> = ({ children }) => {
         <RenownLogo aria-label="Renown" className="text-foreground" />
       </div>
       <div className="absolute right-8 top-3 z-10 flex items-center gap-3">
-        <RenownLoginButton />
+        {!hideLoginButton && <RenownLoginButton />}
         <ThemeToggle />
       </div>
 

--- a/pages/console.tsx
+++ b/pages/console.tsx
@@ -13,7 +13,7 @@ const ConsolePage: NextPage = () => {
     const isClient = useIsClient();
 
     return (
-        <PageBackground>
+        <PageBackground hideLoginButton={Boolean(sessionId) && isClient}>
             <div className={styles.container}>
                 <Head>
                     <title>Renown - Console Login</title>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -14,8 +14,10 @@ const Home: NextPage = () => {
     const returnUrl = router.query["returnUrl"]?.toString();
     const isClient = useIsClient();
 
+    const inAuthFlow = Boolean(appId) && isClient;
+
     return (
-        <PageBackground>
+        <PageBackground hideLoginButton={inAuthFlow}>
             <div className={styles.container}>
                 <Head>
                     <title>Renown</title>


### PR DESCRIPTION
## Summary

On the auth confirmation screens (e.g. `/?app=…&connect=…&returnUrl=…` and the `/console` CLI login), the top-right **Login** button competed with the confirm form. Users sometimes clicked it instead of confirming the authorization, causing a confusing flow.

This hides the topbar login button while an auth flow is active, so the user's attention stays on the confirm card.

## Changes

- `PageBackground` gains an optional `hideLoginButton` prop (default `false`).
- `pages/index.tsx` — enables it when an auth flow is active (`app`/`connect` query param present).
- `pages/console.tsx` — enables it during the CLI login flow (`session` query param present).

Default behavior is unchanged: the landing page and profile pages still show the login button.