### PR TITLE
refactor(api): centralize switchboard client + fix action timestamp format

### DIFF
--- a/pages/api/auth/credential.ts
+++ b/pages/api/auth/credential.ts
@@ -1,16 +1,10 @@
 import { NextApiRequest, NextApiResponse } from 'next/types'
 import { allowCors } from '../[utils]'
-import { GraphQLClient } from 'graphql-request'
 import { revokeCredential } from '../../../services/renown-credential'
+import { queryRenownCredentials, queryRenownUsers } from '../../../services/switchboard'
 import { CREDENTIAL_TYPES } from '../../../services/wallet'
-import { DEFAULT_DRIVE_ID } from '../../../utils/constants'
-
-const SWITCHBOARD_ENDPOINT =
-  process.env.NEXT_PUBLIC_SWITCHBOARD_ENDPOINT || 'https://switchboard.renown.vetra.io/graphql'
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const client = new GraphQLClient(SWITCHBOARD_ENDPOINT)
-
   if (req.method === 'GET') {
     // Get credentials by address/chainId/appId
     const { address, chainId, appId, connectId, driveId, includeRevoked } = req.query
@@ -25,102 +19,27 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     const finalDriveId = (driveId as string) || userDriveId
 
     try {
-      // Query RenownCredential documents by eth address
-      const GET_CREDENTIALS_QUERY = `
-        query GetRenownCredentials($input: RenownCredentialsInput!) {
-          renownCredentials(input: $input) {
-            documentId
-            credentialId
-            context
-            type
-            issuerId
-            issuerEthereumAddress
-            issuanceDate
-            expirationDate
-            credentialSubjectId
-            credentialSubjectApp
-            credentialStatusId
-            credentialStatusType
-            credentialSchemaId
-            credentialSchemaType
-            proofVerificationMethod
-            proofEthereumAddress
-            proofCreated
-            proofPurpose
-            proofType
-            proofValue
-            proofEip712Domain
-            proofEip712PrimaryType
-            revoked
-            revokedAt
-            revocationReason
-            createdAt
-            updatedAt
-          }
-        }
-      `
-
       // Pass app DID to the subgraph query for server-side filtering
       const appDid = appId || connectId
 
       // Profile doc id fetched concurrently but as a SEPARATE request, so a
       // failure degrades to undefined instead of failing the credential fetch.
-      const userDocumentIdPromise = client
-        .request<{ renownUsers: { documentId: string }[] }>(
-          `query RenownUsers($input: RenownUsersInput!) { renownUsers(input: $input) { documentId } }`,
-          {
-            input: {
-              driveId: finalDriveId,
-              ethAddresses: [(address as string).toLowerCase()],
-            },
-          },
-        )
-        .then((d) => d.renownUsers[0]?.documentId)
+      const userDocumentIdPromise = queryRenownUsers({
+        driveId: finalDriveId,
+        ethAddresses: [(address as string).toLowerCase()],
+      })
+        .then((users) => users[0]?.documentId)
         .catch((e) => {
           console.error('Failed to fetch user profile documentId:', e)
           return undefined as string | undefined
         })
 
-      const credentialsData = await client.request<{
-        renownCredentials: Array<{
-          documentId: string
-          credentialId: string
-          context: string[]
-          type: string[]
-          issuerId: string
-          issuerEthereumAddress: string
-          issuanceDate: string
-          expirationDate: string | null
-          credentialSubjectId: string | null
-          credentialSubjectApp: string
-          credentialStatusId: string | null
-          credentialStatusType: string | null
-          credentialSchemaId: string
-          credentialSchemaType: string
-          proofVerificationMethod: string
-          proofEthereumAddress: string
-          proofCreated: string
-          proofPurpose: string
-          proofType: string
-          proofValue: string
-          proofEip712Domain: string
-          proofEip712PrimaryType: string
-          revoked: boolean
-          revokedAt: string | null
-          revocationReason: string | null
-          createdAt: string | null
-          updatedAt: string | null
-        }>
-      }>(GET_CREDENTIALS_QUERY, {
-        input: {
-          driveId: finalDriveId,
-          ethAddress: (address as string).toLowerCase(),
-          did: appDid as string | undefined,
-          includeRevoked: includeRevoked === 'true',
-        },
+      let credentials = await queryRenownCredentials({
+        driveId: finalDriveId,
+        ethAddress: (address as string).toLowerCase(),
+        did: appDid as string | undefined,
+        includeRevoked: includeRevoked === 'true',
       })
-
-      let credentials = credentialsData.renownCredentials
 
       console.log(
         `Found ${credentials.length} credentials for address ${address} ${appDid ? `and app ${appDid}` : ''}`,

--- a/pages/api/auth/verify.ts
+++ b/pages/api/auth/verify.ts
@@ -1,10 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next/types";
 import { allowCors } from "../[utils]";
-import { GraphQLClient, gql } from 'graphql-request';
-
-const SWITCHBOARD_ENDPOINT =
-  process.env.NEXT_PUBLIC_SWITCHBOARD_ENDPOINT ||
-  'https://switchboard.renown.vetra.io/graphql';
+import { queryRenownCredentials } from "../../../services/switchboard";
 
 interface VerifyRequest {
   token: string; // This is now a credentialId
@@ -16,36 +12,6 @@ interface VerifyResponse {
   payload?: any;
   error?: string;
 }
-
-const GET_CREDENTIALS_BY_ADDRESS_QUERY = gql`
-  query GetCredentialsByAddress($input: RenownCredentialsInput!) {
-    renownCredentials(input: $input) {
-      documentId
-      credentialId
-      context
-      type
-      issuerId
-      issuerEthereumAddress
-      issuanceDate
-      expirationDate
-      credentialSubjectId
-      credentialSubjectApp
-      credentialSchemaId
-      credentialSchemaType
-      proofVerificationMethod
-      proofEthereumAddress
-      proofCreated
-      proofPurpose
-      proofType
-      proofValue
-      proofEip712Domain
-      proofEip712PrimaryType
-      revoked
-      revokedAt
-      revocationReason
-    }
-  }
-`;
 
 async function handler(req: NextApiRequest, res: NextApiResponse<VerifyResponse>) {
   if (req.method !== "POST") {
@@ -66,47 +32,17 @@ async function handler(req: NextApiRequest, res: NextApiResponse<VerifyResponse>
   }
 
   try {
-    const client = new GraphQLClient(SWITCHBOARD_ENDPOINT);
-
     // Use user-specific drive based on address
     const userDriveId = `renown-${address.toLowerCase()}`;
 
     // Query for credentials by address in the user's drive
-    const data = await client.request<{
-      renownCredentials: Array<{
-        documentId: string;
-        credentialId: string;
-        context: string[];
-        type: string[];
-        issuerId: string;
-        issuerEthereumAddress: string;
-        issuanceDate: string;
-        expirationDate: string | null;
-        credentialSubjectId: string | null;
-        credentialSubjectApp: string;
-        credentialSchemaId: string;
-        credentialSchemaType: string;
-        proofVerificationMethod: string;
-        proofEthereumAddress: string;
-        proofCreated: string;
-        proofPurpose: string;
-        proofType: string;
-        proofValue: string;
-        proofEip712Domain: string;
-        proofEip712PrimaryType: string;
-        revoked: boolean;
-        revokedAt: string | null;
-        revocationReason: string | null;
-      }>;
-    }>(GET_CREDENTIALS_BY_ADDRESS_QUERY, {
-      input: {
-        driveId: userDriveId,
-        ethAddress: address,
-        includeRevoked: true,
-      },
+    const credentials = await queryRenownCredentials({
+      driveId: userDriveId,
+      ethAddress: address,
+      includeRevoked: true,
     });
 
-    if (!data.renownCredentials || data.renownCredentials.length === 0) {
+    if (credentials.length === 0) {
       res.status(404).json({
         valid: false,
         error: "Credential not found",
@@ -115,7 +51,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse<VerifyResponse>
     }
 
     // Find the credential with the matching ID
-    const credential = data.renownCredentials.find(cred => cred.credentialId === token);
+    const credential = credentials.find(cred => cred.credentialId === token);
 
     if (!credential) {
       res.status(404).json({

--- a/pages/api/credential/renown.ts
+++ b/pages/api/credential/renown.ts
@@ -1,24 +1,15 @@
 // v6 reactor API - uses createEmptyDocument + mutateDocument
 import { NextApiRequest, NextApiResponse } from 'next/types'
 import { allowCors } from '../[utils]'
-import { GraphQLClient } from 'graphql-request'
-import { v4 as uuidv4 } from 'uuid'
 import { storeCredential, revokeCredential } from '../../../services/renown-credential'
+import {
+  createEmptyDocument,
+  makeAction,
+  mutateDocument,
+  queryRenownCredentials,
+  queryRenownUsers,
+} from '../../../services/switchboard'
 import { DEFAULT_DRIVE_ID } from '../../../utils/constants'
-
-function makeAction(type: string, input: Record<string, unknown>) {
-  return {
-    id: uuidv4(),
-    type,
-    input,
-    scope: 'global',
-    timestampUtcMs: Date.now(),
-  }
-}
-
-const SWITCHBOARD_ENDPOINT =
-  process.env.NEXT_PUBLIC_SWITCHBOARD_ENDPOINT ||
-  'https://switchboard.renown.vetra.io/graphql'
 
 interface EIP712Domain {
   version: string
@@ -46,8 +37,6 @@ interface EIP712Credential {
 }
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
-  const client = new GraphQLClient(SWITCHBOARD_ENDPOINT)
-
   if (req.method === 'POST') {
     // Create/Add an EIP-712 credential
     const { driveId, docId, credential, signature, domain, username, userImage } = req.body as {
@@ -95,26 +84,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
         console.log('Setting up user drive for ethAddress:', ethAddress)
 
         // Try to find existing RenownUser document
-        const GET_PROFILE_QUERY = `
-          query RenownUsers($input: RenownUsersInput!) {
-            renownUsers(input: $input) {
-              documentId
-              ethAddress
-            }
-          }
-        `
-
-        const profileData = await client.request<{
-          renownUsers: { documentId: string; ethAddress: string }[]
-        }>(GET_PROFILE_QUERY, {
-          input: {
-            driveId: userDriveId,
-            ethAddresses: [ethAddress],
-          },
+        const existingUsers = await queryRenownUsers({
+          driveId: userDriveId,
+          ethAddresses: [ethAddress],
         })
 
-        if (profileData.renownUsers.length > 0) {
-          const existingId = profileData.renownUsers[0].documentId
+        if (existingUsers.length > 0) {
+          const existingId = existingUsers[0].documentId
           console.log('Found existing RenownUser document:', existingId)
 
           // Refresh username/userImage on the existing document
@@ -128,16 +104,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
           if (updateActions.length > 0) {
             try {
-              await client.request(`
-                mutation MutateDocument($documentIdentifier: String!, $actions: [JSONObject!]!) {
-                  mutateDocument(documentIdentifier: $documentIdentifier, actions: $actions) {
-                    id
-                  }
-                }
-              `, {
-                documentIdentifier: existingId,
-                actions: updateActions,
-              })
+              await mutateDocument(existingId, updateActions)
             } catch (e) {
               console.error('Failed to update user fields:', e)
             }
@@ -147,19 +114,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
         // Create RenownUser document
         console.log('Creating RenownUser document')
-        const createResult = await client.request<{
-          createEmptyDocument: { id: string }
-        }>(`
-          mutation CreateEmptyDocument($documentType: String!) {
-            createEmptyDocument(documentType: $documentType) {
-              id
-            }
-          }
-        `, {
-          documentType: 'powerhouse/renown-user',
-        })
-
-        const newId = createResult.createEmptyDocument.id
+        const newId = await createEmptyDocument('powerhouse/renown-user')
         console.log('Created new RenownUser document:', newId)
 
         // Set eth address, username, and userImage in a single mutateDocument call
@@ -171,16 +126,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
           actions.push(makeAction('SET_USER_IMAGE', { userImage }))
         }
 
-        await client.request(`
-          mutation MutateDocument($documentIdentifier: String!, $actions: [JSONObject!]!) {
-            mutateDocument(documentIdentifier: $documentIdentifier, actions: $actions) {
-              id
-            }
-          }
-        `, {
-          documentIdentifier: newId,
-          actions,
-        })
+        await mutateDocument(newId, actions)
 
         console.log('Set user fields on document')
         return newId
@@ -236,25 +182,13 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     try {
       // Resolve the credential URI to its document ID by querying the user's drive
       const userDriveId = `renown-${address.toLowerCase()}`
-      const LOOKUP_QUERY = `
-        query LookupCredential($input: RenownCredentialsInput!) {
-          renownCredentials(input: $input) {
-            documentId
-            credentialId
-          }
-        }
-      `
-      const lookup = await client.request<{
-        renownCredentials: { documentId: string; credentialId: string }[]
-      }>(LOOKUP_QUERY, {
-        input: {
-          driveId: userDriveId,
-          ethAddress: address.toLowerCase(),
-          includeRevoked: false,
-        },
+      const credentials = await queryRenownCredentials({
+        driveId: userDriveId,
+        ethAddress: address.toLowerCase(),
+        includeRevoked: false,
       })
 
-      const match = lookup.renownCredentials.find(c => c.credentialId === credentialId)
+      const match = credentials.find(c => c.credentialId === credentialId)
       if (!match) {
         res.status(404).json({ error: 'Credential not found' })
         return

--- a/pages/api/profile.ts
+++ b/pages/api/profile.ts
@@ -1,40 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next/types'
 import { allowCors } from './[utils]'
-import { GraphQLClient } from 'graphql-request'
+import { queryRenownUsers, type RenownUsersInput } from '../../services/switchboard'
 import { DEFAULT_DRIVE_ID } from '../../utils/constants'
-
-const SWITCHBOARD_ENDPOINT =
-  process.env.NEXT_PUBLIC_SWITCHBOARD_ENDPOINT ||
-  'https://switchboard.renown.vetra.io/graphql'
-
-const GET_PROFILE_QUERY = `
-    query ($input: RenownUsersInput!) {
-        renownUsers(input: $input) {
-            createdAt
-            documentId
-            ethAddress
-            updatedAt
-            userImage
-            username
-        }
-    }
-`
-
-interface RenownUsersInput {
-  driveId?: string
-  phids?: string[]
-  ethAddresses?: string[]
-  usernames?: string[]
-}
-
-interface Profile {
-  createdAt: string
-  documentId: string
-  ethAddress: string
-  updatedAt: string
-  userImage?: string
-  username?: string
-}
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method === 'POST') {
@@ -61,11 +28,10 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     try {
-      const client = new GraphQLClient(SWITCHBOARD_ENDPOINT)
-      const data = await client.request<{ renownUsers: Profile[] }>(GET_PROFILE_QUERY, { input })
+      const users = await queryRenownUsers(input)
 
       // Return first result or null
-      const profile = data.renownUsers.length > 0 ? data.renownUsers[0] : null
+      const profile = users.length > 0 ? users[0] : null
       res.status(200).json({ profile })
     } catch (e) {
       console.error('Failed to fetch profile:', e)

--- a/pages/api/status/[address].ts
+++ b/pages/api/status/[address].ts
@@ -1,51 +1,9 @@
 import { NextApiRequest, NextApiResponse } from 'next/types'
 import { allowCors } from '../[utils]'
-import { GraphQLClient, gql } from 'graphql-request'
-import { DEFAULT_DRIVE_ID } from '../../../utils/constants'
-
-const SWITCHBOARD_ENDPOINT =
-  process.env.NEXT_PUBLIC_SWITCHBOARD_ENDPOINT ||
-  'https://switchboard.renown.vetra.io/graphql'
-
-interface RenownCredential {
-  documentId: string
-  credentialId: string
-  context: string[]
-  type: string[]
-  issuerId: string
-  issuerEthereumAddress: string
-  issuanceDate: string
-  expirationDate: string | null
-  credentialSubjectId: string | null
-  credentialSubjectApp: string
-  revoked: boolean
-  revokedAt: string | null
-  revocationReason: string | null
-  createdAt: string | null
-  updatedAt: string | null
-}
-
-const GET_CREDENTIALS_QUERY = gql`
-  query RenownCredentials($input: RenownCredentialsInput!) {
-    renownCredentials(input: $input) {
-      documentId
-      credentialId
-      context
-      type
-      issuerId
-      issuerEthereumAddress
-      issuanceDate
-      expirationDate
-      credentialSubjectId
-      credentialSubjectApp
-      revoked
-      revokedAt
-      revocationReason
-      createdAt
-      updatedAt
-    }
-  }
-`
+import {
+  queryRenownCredentials,
+  type RenownCredentialsInput,
+} from '../../../services/switchboard'
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -65,10 +23,8 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   try {
-    const client = new GraphQLClient(SWITCHBOARD_ENDPOINT)
-
     // Build the query input
-    const queryInput: any = {
+    const queryInput: RenownCredentialsInput = {
       includeRevoked,
       did: appDid,
     }
@@ -100,13 +56,9 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     console.log('Querying credentials with input:', queryInput)
 
     // Query for credentials
-    const data = await client.request<{
-      renownCredentials: RenownCredential[]
-    }>(GET_CREDENTIALS_QUERY, {
-      input: queryInput,
-    })
+    const credentials = await queryRenownCredentials(queryInput)
 
-    if (!data.renownCredentials || data.renownCredentials.length === 0) {
+    if (credentials.length === 0) {
       res.status(404).json({
         error: 'Credential not found',
         searched: queryInput,
@@ -115,7 +67,7 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
     }
 
     // Return the most recent credential by issuanceDate
-    const matchedCredential = data.renownCredentials.reduce((prev, curr) =>
+    const matchedCredential = credentials.reduce((prev, curr) =>
       prev.issuanceDate > curr.issuanceDate ? prev : curr
     )
 

--- a/services/renown-credential.ts
+++ b/services/renown-credential.ts
@@ -1,35 +1,4 @@
-import { request, gql } from 'graphql-request'
-import { v4 as uuidv4 } from 'uuid'
-
-function makeAction(type: string, input: Record<string, unknown>) {
-  return {
-    id: uuidv4(),
-    type,
-    input,
-    scope: 'global',
-    timestampUtcMs: Date.now(),
-  }
-}
-
-const SWITCHBOARD_URL =
-  process.env.NEXT_PUBLIC_SWITCHBOARD_ENDPOINT ||
-  'https://switchboard.renown.vetra.io/graphql'
-
-const CREATE_EMPTY_DOCUMENT = gql`
-  mutation CreateEmptyDocument($documentType: String!, $parentIdentifier: String) {
-    createEmptyDocument(documentType: $documentType, parentIdentifier: $parentIdentifier) {
-      id
-    }
-  }
-`
-
-const MUTATE_DOCUMENT = gql`
-  mutation MutateDocument($documentIdentifier: String!, $actions: [JSONObject!]!) {
-    mutateDocument(documentIdentifier: $documentIdentifier, actions: $actions) {
-      id
-    }
-  }
-`
+import { createEmptyDocument, makeAction, mutateDocument } from './switchboard'
 
 interface EIP712Domain {
   version: string
@@ -56,9 +25,7 @@ interface EIP712Credential {
   expirationDate: string
 }
 
-/**
- * Create and initialize a new RenownCredential document with EIP-712 credential
- */
+// Create and initialize a new RenownCredential document with EIP-712 credential
 export async function storeCredential(params: {
   driveId?: string
   credential: EIP712Credential
@@ -67,14 +34,10 @@ export async function storeCredential(params: {
   ethAddress: string
 }): Promise<{ success: boolean; credentialId?: string }> {
   try {
-    const { credential, signature, domain, ethAddress } = params
+    const { credential, signature, domain } = params
 
     // Create a new RenownCredential document
-    const createResult = (await request(SWITCHBOARD_URL, CREATE_EMPTY_DOCUMENT, {
-      documentType: 'powerhouse/renown-credential',
-    })) as { createEmptyDocument: { id: string } }
-
-    const credentialId = createResult.createEmptyDocument.id
+    const credentialId = await createEmptyDocument('powerhouse/renown-credential')
 
     if (!credentialId) {
       throw new Error('Failed to create credential document')
@@ -117,10 +80,7 @@ export async function storeCredential(params: {
     }
 
     // Initialize the credential with EIP-712 data
-    await request(SWITCHBOARD_URL, MUTATE_DOCUMENT, {
-      documentIdentifier: credentialId,
-      actions: [makeAction('INIT', initInput)],
-    })
+    await mutateDocument(credentialId, [makeAction('INIT', initInput)])
 
     return {
       success: true,
@@ -132,22 +92,19 @@ export async function storeCredential(params: {
   }
 }
 
-/**
- * Revoke an existing credential
- */
+// Revoke an existing credential
 export async function revokeCredential(params: {
   credentialId: string
   reason?: string
   revokedAt?: string
 }): Promise<boolean> {
   try {
-    await request(SWITCHBOARD_URL, MUTATE_DOCUMENT, {
-      documentIdentifier: params.credentialId,
-      actions: [makeAction('REVOKE', {
+    await mutateDocument(params.credentialId, [
+      makeAction('REVOKE', {
         revokedAt: params.revokedAt || new Date().toISOString(),
         reason: params.reason || null,
-      })],
-    })
+      }),
+    ])
 
     return true
   } catch (error) {

--- a/services/switchboard.ts
+++ b/services/switchboard.ts
@@ -1,19 +1,71 @@
-import { GraphQLClient } from 'graphql-request'
+import { GraphQLClient, gql } from 'graphql-request'
+import { v4 as uuidv4 } from 'uuid'
 
-const SWITCHBOARD_ENDPOINT =
+export const SWITCHBOARD_ENDPOINT =
   process.env.NEXT_PUBLIC_SWITCHBOARD_ENDPOINT ||
-  'http://localhost:4001/graphql'
+  'https://switchboard.renown.vetra.io/graphql'
 
-const client = new GraphQLClient(SWITCHBOARD_ENDPOINT)
+export const switchboardClient = new GraphQLClient(SWITCHBOARD_ENDPOINT)
 
-interface GetProfileInput {
-  driveId: string
-  id?: string
-  username?: string
-  ethAddress?: string
+// Reactor action envelope. `timestampUtcMs` must be an ISO-8601 UTC string:
+// despite the name, the reactor validates/stores it as a timestamp, not ms.
+export function makeAction(type: string, input: Record<string, unknown>) {
+  return {
+    id: uuidv4(),
+    type,
+    input,
+    scope: 'global',
+    timestampUtcMs: new Date().toISOString(),
+  }
 }
 
-export interface RenownProfile {
+export type ReactorAction = ReturnType<typeof makeAction>
+
+// --- Reactor write primitives ---------------------------------------------
+
+const CREATE_EMPTY_DOCUMENT = gql`
+  mutation CreateEmptyDocument($documentType: String!, $parentIdentifier: String) {
+    createEmptyDocument(documentType: $documentType, parentIdentifier: $parentIdentifier) {
+      id
+    }
+  }
+`
+
+const MUTATE_DOCUMENT = gql`
+  mutation MutateDocument($documentIdentifier: String!, $actions: [JSONObject!]!) {
+    mutateDocument(documentIdentifier: $documentIdentifier, actions: $actions) {
+      id
+    }
+  }
+`
+
+export async function createEmptyDocument(
+  documentType: string,
+  parentIdentifier?: string,
+): Promise<string> {
+  const res = await switchboardClient.request<{
+    createEmptyDocument: { id: string }
+  }>(CREATE_EMPTY_DOCUMENT, { documentType, parentIdentifier })
+  return res.createEmptyDocument.id
+}
+
+export async function mutateDocument(
+  documentIdentifier: string,
+  actions: ReactorAction[],
+): Promise<void> {
+  await switchboardClient.request(MUTATE_DOCUMENT, { documentIdentifier, actions })
+}
+
+// --- Read-model queries ----------------------------------------------------
+
+export interface RenownUsersInput {
+  driveId?: string
+  phids?: string[]
+  ethAddresses?: string[]
+  usernames?: string[]
+}
+
+export interface ReadRenownUser {
   documentId: string
   username?: string | null
   ethAddress?: string | null
@@ -22,14 +74,7 @@ export interface RenownProfile {
   updatedAt?: string | null
 }
 
-interface RenownUsersInput {
-  driveId?: string
-  phids?: string[]
-  ethAddresses?: string[]
-  usernames?: string[]
-}
-
-const GET_PROFILE_QUERY = `
+const RENOWN_USERS_QUERY = gql`
   query RenownUsers($input: RenownUsersInput!) {
     renownUsers(input: $input) {
       documentId
@@ -42,21 +87,120 @@ const GET_PROFILE_QUERY = `
   }
 `
 
-export async function getProfile(input: GetProfileInput): Promise<RenownProfile | null> {
+export async function queryRenownUsers(
+  input: RenownUsersInput,
+): Promise<ReadRenownUser[]> {
+  const data = await switchboardClient.request<{ renownUsers: ReadRenownUser[] }>(
+    RENOWN_USERS_QUERY,
+    { input },
+  )
+  return data.renownUsers
+}
+
+export interface RenownCredentialsInput {
+  driveId?: string
+  ethAddress?: string
+  did?: string
+  issuer?: string
+  includeRevoked?: boolean
+}
+
+export interface ReadRenownCredential {
+  documentId: string
+  credentialId: string
+  context: string[]
+  type: string[]
+  issuerId: string
+  issuerEthereumAddress: string
+  issuanceDate: string
+  expirationDate: string | null
+  credentialSubjectId: string | null
+  credentialSubjectApp: string
+  credentialStatusId: string | null
+  credentialStatusType: string | null
+  credentialSchemaId: string
+  credentialSchemaType: string
+  proofVerificationMethod: string
+  proofEthereumAddress: string
+  proofCreated: string
+  proofPurpose: string
+  proofType: string
+  proofValue: string
+  proofEip712Domain: string
+  proofEip712PrimaryType: string
+  revoked: boolean
+  revokedAt: string | null
+  revocationReason: string | null
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+const RENOWN_CREDENTIALS_QUERY = gql`
+  query GetRenownCredentials($input: RenownCredentialsInput!) {
+    renownCredentials(input: $input) {
+      documentId
+      credentialId
+      context
+      type
+      issuerId
+      issuerEthereumAddress
+      issuanceDate
+      expirationDate
+      credentialSubjectId
+      credentialSubjectApp
+      credentialStatusId
+      credentialStatusType
+      credentialSchemaId
+      credentialSchemaType
+      proofVerificationMethod
+      proofEthereumAddress
+      proofCreated
+      proofPurpose
+      proofType
+      proofValue
+      proofEip712Domain
+      proofEip712PrimaryType
+      revoked
+      revokedAt
+      revocationReason
+      createdAt
+      updatedAt
+    }
+  }
+`
+
+export async function queryRenownCredentials(
+  input: RenownCredentialsInput,
+): Promise<ReadRenownCredential[]> {
+  const data = await switchboardClient.request<{
+    renownCredentials: ReadRenownCredential[]
+  }>(RENOWN_CREDENTIALS_QUERY, { input })
+  return data.renownCredentials
+}
+
+// --- Convenience ------------------------------------------------------------
+
+interface GetProfileInput {
+  driveId: string
+  id?: string
+  username?: string
+  ethAddress?: string
+}
+
+// Kept for backwards compatibility; prefer queryRenownUsers directly.
+export type RenownProfile = ReadRenownUser
+
+export async function getProfile(
+  input: GetProfileInput,
+): Promise<RenownProfile | null> {
   try {
-    const renownUsersInput: RenownUsersInput = {
+    const users = await queryRenownUsers({
       driveId: input.driveId,
       ...(input.id && { phids: [input.id] }),
       ...(input.ethAddress && { ethAddresses: [input.ethAddress] }),
       ...(input.username && { usernames: [input.username] }),
-    }
-
-    const data = await client.request<{ renownUsers: RenownProfile[] }>(GET_PROFILE_QUERY, {
-      input: renownUsersInput,
     })
-
-    // Return first result or null
-    return data.renownUsers.length > 0 ? data.renownUsers[0] : null
+    return users.length > 0 ? users[0] : null
   } catch (error) {
     console.error('Failed to fetch profile from switchboard:', error)
     return null


### PR DESCRIPTION
## Summary

Consolidates all switchboard GraphQL access into a single service and fixes a write-blocking bug against newer reactor versions. Pure refactor + one correctness fix — no behavior change to the login flow.

### Changes
- **`services/switchboard.ts` is now the single client**: exports the endpoint constant, a shared `GraphQLClient`, `makeAction`, `createEmptyDocument`/`mutateDocument` write helpers, and `queryRenownUsers`/`queryRenownCredentials` with shared result types.
- **7 routes/services de-duplicated**: each used to re-declare a `GraphQLClient`, the endpoint (one even defaulted to `localhost` while the rest defaulted to prod), inline `gql` queries, and their own result interfaces. They now import the shared helpers. **−192 net lines.**
- **Fix — action timestamp format.** `makeAction` set `timestampUtcMs: Date.now()` (a number). Reactor **≥6.1.0** validates this field as an **ISO-8601 string** (`isValidISOTimestamp`) and stores it in a `timestamptz` column, so numeric timestamps fail *every* write with `Invalid timestamp`. `makeAction` now emits `new Date().toISOString()`. (6.0.x had no validation, so it silently accepted the number — this only surfaces when the switchboard upgrades.)

### Preserved deliberately
- Parallel reads in `GET /api/auth/credential` and the concurrent `Promise.all` writes in `POST /api/credential/renown`, plus their best-effort `.catch` degradation (from the earlier round-trip PR).
- DID parsing and VC building left as-is (follow-ups: use `@renown/sdk`'s `parsePkhDid` / `buildAndSignCredential`).

## Test plan
- [x] `tsc` clean, `eslint` clean on all 7 files
- [x] End-to-end against a production DB snapshot on a **6.1.0** switchboard: reads, existing-credential auth (`/api/auth/credential` + `/api/auth/verify` + `/api/profile`), and new-credential create→read→verify all succeed
- [x] Confirmed writes were failing pre-fix (500 `Invalid timestamp`) and pass post-fix (200)

https://claude.ai/code/session_01Hyb74ipTGtRE2ptxuALxjf
